### PR TITLE
Ft0002/signup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,10 @@ services:
 
       SPRING_MAIL_HOST: smtp.gmail.com
       SPRING_MAIL_PORT: 587
-      SPRING_MAIL_USERNAME: minzayarmaung2002@gmail.com
-      SPRING_MAIL_PASSWORD: vgklvkranagneybo
+      # SPRING_MAIL_USERNAME: minzayarmaung2002@gmail.com
+      # SPRING_MAIL_PASSWORD: vgklvkranagneybo
+      SPRING_MAIL_USERNAME: winminthant.gwin@gmail.com
+      SPRING_MAIL_PASSWORD: aqtl wula wqvo xbqu
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH: "true"
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: "true"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,10 +35,8 @@ services:
 
       SPRING_MAIL_HOST: smtp.gmail.com
       SPRING_MAIL_PORT: 587
-      # SPRING_MAIL_USERNAME: minzayarmaung2002@gmail.com
-      # SPRING_MAIL_PASSWORD: vgklvkranagneybo
-      SPRING_MAIL_USERNAME: winminthant.gwin@gmail.com
-      SPRING_MAIL_PASSWORD: aqtl wula wqvo xbqu
+      SPRING_MAIL_USERNAME: minzayarmaung2002@gmail.com
+      SPRING_MAIL_PASSWORD: vgklvkranagneybo
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH: "true"
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: "true"
 

--- a/src/app/components/ui/FormWrapper.jsx
+++ b/src/app/components/ui/FormWrapper.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Button from './Button';
 
-const FormWrapper = ({ title, subtitle, children, onSubmit, className, loading }) => (
+const FormWrapper = ({ title, subtitle, children, onSubmit, className, loading, buttonText = "Continue" }) => (
         <form className={`text-white font-sans text-sm font-semibold leading-8 ${className}`}>
             <div className="text-2xl text-center space-y-2">
             <h2 className='text-2xl'>{title}</h2>
@@ -23,7 +23,7 @@ const FormWrapper = ({ title, subtitle, children, onSubmit, className, loading }
                         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>
                     )}
-                    Continue
+                    {buttonText}
                 </div>
             </Button>
         </form>

--- a/src/app/constants/lazyload.jsx
+++ b/src/app/constants/lazyload.jsx
@@ -29,10 +29,6 @@ export const ForgotPasswordPage = PageLoader(
   lazy(() => import("@/features/auth/pages/ForgotPasswordPage"))
 );
 
-export const CheckPasswordOtpPage = PageLoader(
-  lazy(() => import("@/features/auth/pages/CheckPasswordOtpPage"))
-);
-
 export const ResetPasswordPage = PageLoader(
   lazy(() => import("@/features/auth/pages/ResetPasswordPage"))
 );

--- a/src/app/features/auth/components/LoginForm.jsx
+++ b/src/app/features/auth/components/LoginForm.jsx
@@ -5,6 +5,7 @@ import TextField from "@/components/ui/TextField";
 import PasswordField from "@/components/ui/PasswordField";
 import { loginWithEmailPassword } from "@/services/authService";
 import { NavLink, useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
 
 function LoginForm() {
   const [password, setPassword] = useState("");
@@ -19,12 +20,6 @@ function LoginForm() {
   const [showEmailError, setShowEmailError] = useState(false);
   const [showPasswordError, setShowPasswordError] = useState(false);
 
-  console.log(emailErrorMsg);
-  console.log(passwordErrorMsg);
-  console.log(showEmailError);
-  console.log(showPasswordError);
-  console.log(email);
-  console.log(password);
 
   //validation
   const validateEmail = (email) => {
@@ -68,27 +63,13 @@ function LoginForm() {
 
     try {
       const data = await loginWithEmailPassword(email, password);
-      console.log("Login success:", data);
-
+      
+      
       if (data.success === 0 || data.code >= 400) {
         throw new Error(data.message || "Login failed. Please try again.");
       }
-
-      if (data?.data.token) {
-        localStorage.setItem("token", data?.data.token);
-
-        // Store user information
-        const userInfo = {
-          id: data?.data.userId,
-          username: data?.data.username,
-          email: data?.data.email,
-          role: data?.data.role,
-          roleId: data?.data.roleId,
-          isNewUserLogin: data?.data.isNewUserLogin,
-        };
-        localStorage.setItem("user", JSON.stringify(userInfo));
-      }
-
+      
+      toast.success("Login successfully!");
       // alert("Login successful!");
       navigate("/setup-profile");
     } catch (err) {

--- a/src/app/features/auth/components/OtpForm.jsx
+++ b/src/app/features/auth/components/OtpForm.jsx
@@ -1,20 +1,20 @@
 import Button from "@/components/ui/Button";
 import OtpInput from "@/components/ui/OtpInput";
 import { useOtpVerification } from "@/features/auth/hooks/useOtpVerification";
-import { signupWithEmail } from "@/services/authService";
 import { useEffect } from "react";
 import toast from "react-hot-toast";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 function OtpForm({
-  // email = "nora@gmail.com",
+  email,
   onVerifySuccess,
-  onBackToSignup,
+  onMaxAttemptsExceeded
 }) {
   const navigate = useNavigate();
-  const location = useLocation();
-  const email = location.state?.email;
-  const password = location.state?.password;
+
+  if (!email) {
+    throw new Error("Email is required for OTP verification");
+  }
 
   const {
     otpData,
@@ -38,79 +38,35 @@ function OtpForm({
     isVerifying,
   } = otpData;
 
-  // Send OTP automatically when component mounts
-  useEffect(() => {
-    const sendInitialOtp = async () => {
-      try {
-        toast.loading("Sending OTP code...", { id: "initial-otp" });
-        await resendOtp();
-        startResendTimer();
-        toast.success("OTP sent successfully! Check your email.", {
-          id: "initial-otp",
-        });
-      } catch (error) {
-        console.error("Failed to send initial OTP:", error);
-        toast.error("Failed to send OTP. Please try resending.", {
-          id: "initial-otp",
-        });
-        setError("Failed to send OTP. Please try resending.");
-      }
-    };
-
-    sendInitialOtp();
-  }, [email]); // Only run when email changes
 
   const handleOtpChange = (value) => {
-    updateOtpValue(value);
+    const stringValue = Array.isArray(value) ? value.join("") : value;
+    updateOtpValue(stringValue);
   };
 
+  useEffect(()=>{
+    startResendTimer();
+  },[])
+
   const handleVerify = async () => {
-    if (otpValue.length !== 6) {
-      toast.error("Please enter a complete 6-digit code.");
-      return;
-    }
+
+    if (otpValue.length !== 6) return toast.error("Please enter a complete 6-digit code.");
 
     try {
       toast.loading("Verifying OTP code...", { id: "verify-otp" });
       const isValid = await verifyOtp(otpValue);
-
+      
       if (isValid) {
-        // If password exists, it's a signup flow.
-        if (password) {
-          toast.success("OTP verified successfully!", { id: "verify-otp" });
-          toast.loading("Creating your account...", { id: "signup" });
-          const signupResponse = await signupWithEmail(email, password);
-          if (signupResponse.code === 200 && signupResponse.success === 1) {
-            toast.success("Signup successful! Redirecting...", { id: "signup" });
-            onVerifySuccess?.();
-            navigate("/setup-profile");
-          } else {
-            toast.error(signupResponse.message || "Signup failed. Please try again.", { id: "signup" });
-          }
-        } else { // Otherwise, it's a forgot password flow.
-          toast.success("🎉 OTP Verified Successfully! Proceed to reset your password.", { id: "verify-otp" });
-          onVerifySuccess?.();
-          navigate("/reset-password", { state: { email } });
-        }
+        toast.dismiss();
+        onVerifySuccess?.();
       } else {
-        toast.error("Invalid OTP code. Please try again.", {
-          id: "verify-otp",
-        });
-        setError("Please enter the valid code.");
-        incrementAttempts();
-
-        const newAttempts = attempts + 1;
-        if (newAttempts >= MAX_ATTEMPTS) {
-          toast.error("Maximum attempts reached. Redirecting to signup...");
-          setTimeout(() => {
-            onBackToSignup?.();
-          }, 1000);
-        }
+          incrementAttempts();
+          if (attempts + 1 >= MAX_ATTEMPTS) {
+            onMaxAttemptsExceeded?.();
+          }
       }
     } catch (error) {
-      toast.error("Verification failed. Please try again.", {
-        id: "verify-otp",
-      });
+      toast.error("Verification failed. Please try again.", {id: "verify-otp",});
       setError("Please enter the valid code.");
       incrementAttempts();
     }
@@ -143,13 +99,6 @@ function OtpForm({
     }
   };
 
-  if (attempts >= MAX_ATTEMPTS) {
-    return (
-      <div className="flex flex-col items-center gap-6 text-white">
-        Route back to sign up page
-      </div>
-    );
-  }
 
   return (
     <div className="flex flex-col items-center gap-6 ">

--- a/src/app/features/auth/components/RegisterForm.jsx
+++ b/src/app/features/auth/components/RegisterForm.jsx
@@ -3,7 +3,7 @@ import FormWrapper from "../../../components/ui/FormWrapper";
 import TextField from "../../../components/ui/TextField";
 import PasswordField from "../../../components/ui/PasswordField";
 import { useLocation, useNavigate } from "react-router-dom";
-import { checkEmailExists, signupWithEmail } from "@/services/authService";
+import { checkEmailExists, loginWithEmailPassword, sendOtpCode, signupWithEmail } from "@/services/authService";
 import toast from "react-hot-toast";
 
 const RegisterForm = () => {
@@ -146,7 +146,14 @@ const RegisterForm = () => {
         return;
       }
 
-      navigate("/otp-verify", { state: { email, password } });
+      // after fill register form, called otp api to verify 
+      const res = await sendOtpCode(email);
+      if(res.code === 200 && res.success === 1){
+          toast.success("OTP resent successfully! Check your email.", {id: "resend-otp",});
+          navigate("/otp-verify", { state: { email, password } });
+      }
+
+        
     } catch (error) {
       console.error("Register error:", error);
       toast.removeAll();
@@ -162,6 +169,7 @@ const RegisterForm = () => {
       subtitle="Please fill in the details below"
       onSubmit={handleSubmit}
       loading={loading}
+      buttonText="Continue"
     >
       <TextField
         ref={emailRef}

--- a/src/app/features/auth/components/ResetPasswordForm.jsx
+++ b/src/app/features/auth/components/ResetPasswordForm.jsx
@@ -1,0 +1,117 @@
+import FormWrapper from '@/components/ui/FormWrapper'
+import PasswordField from '@/components/ui/PasswordField'
+import { resetPassword } from '@/services/authService';
+import React, { useRef, useState } from 'react'
+import toast from 'react-hot-toast';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+
+
+const ResetPasswordForm = () => {
+
+    const [passwordError, setPasswordError] = useState("");
+    const [cmfPasswordError, setCmfPasswordError] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [passwordRestted, setPasswordRestted] = useState(false);
+
+  const navigate = useNavigate();
+    const location = useLocation();
+    const email = location.state?.email;
+
+    const passwordRef = useRef();
+    const cfmpasswordRef = useRef();
+
+    // Strong password validation (8+ chars, uppercase, lowercase, number, special char)
+    const isStrongPassword = (password) =>
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/.test(password);
+
+
+     // Handle form submit
+    const handlePasswordReset = async (e) => {
+        e.preventDefault();
+
+        const password = passwordRef.current.value.trim();
+        const confirmPassword = cfmpasswordRef.current.value.trim();
+
+        setPasswordError("");
+        setCmfPasswordError("");
+
+        // Validation
+        let valid = true;
+
+        //  Password validation
+        if (!password) {
+        setPasswordError("Enter your Password");
+        valid = false;
+        } else if (!isStrongPassword(password)) {
+        setPasswordError(
+            "Password must be at least 8 characters, include upper/lowercase, number, and symbol."
+        );
+        valid = false;
+        }
+
+        // Confirm password validation
+        if (!confirmPassword) {
+        setCmfPasswordError("Confirm your Password");
+        valid = false;
+        } else if (confirmPassword !== password) {
+        setCmfPasswordError("Passwords do not match");
+        valid = false;
+        }
+
+        if (!email) {
+        toast.error("Session expired or email not found. Please start over.");
+        navigate("/forgot-password");
+        return;
+        }
+
+        if (!valid) return;
+
+        setLoading(true);
+
+        try {
+            await resetPassword(email, password);
+            toast.success("Password updated successfully! Please log in.", { id: "reset-password" });
+            setPasswordRestted(true)
+        } catch (error) {
+            toast.error(error.message || "Failed to reset password. Please try again.", { id: "reset-password" });
+        } finally {
+            setLoading(false);
+        }
+    };
+    
+    const handleContinue = async(e) =>{
+        e.preventDefault();
+        navigate("/login");
+    }
+  return (
+    <>
+    {!passwordRestted ?
+        (
+            <FormWrapper title="Reset password" onSubmit={handlePasswordReset} loading={loading} buttonText="Update password">
+                <PasswordField
+                    ref={passwordRef}
+                    name="password"
+                    id="password"
+                    label="Password"
+                    placeholder="Enter your password"
+                    error={passwordError}
+                />
+                <PasswordField
+                    ref={cfmpasswordRef}
+                    name="cfmpassword"
+                    id="cfmpassword"
+                    label="Confirm Password"
+                    placeholder="Confirm your password"
+                    error={cmfPasswordError}
+                />
+            </FormWrapper>
+        ):(
+           <FormWrapper title="Successful" subtitle="Congratulations! Your password has been changer. Click continue to login." onSubmit={handleContinue} loading={loading} buttonText="Continue"><div className='my-8'></div></FormWrapper> 
+        )
+    }
+    </>
+  )
+}
+
+export default ResetPasswordForm

--- a/src/app/features/auth/pages/ForgotPasswordPage.jsx
+++ b/src/app/features/auth/pages/ForgotPasswordPage.jsx
@@ -3,53 +3,46 @@ import Background from "@/components/ui/Background";
 import FormBackground from "@/components/ui/FormBackground";
 import TextField from "@/components/ui/TextField";
 import Button from "@/components/ui/Button";
-import { forgotPassword } from "@/services/authService";
+import { checkEmailExists, forgotPassword } from "@/services/authService";
 import { useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
 
 function ForgotPasswordPage() {
   const [email, setEmail] = useState("");
-  const [error, setError] = useState("");
+  const [emailError, setEmailError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [emailErrorMsg, setEmailErrorMsg] = useState("");
-  const [showEmailError, setShowEmailError] = useState(false);
   const navigate = useNavigate();
 
-  const validateEmail = (email) => {
-    const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 
-    if (!email.trim()) {
-      return "Email is required";
-    } else if (!emailRegex.test(email)) {
-      return "Invalid email address";
-    }
-    return "";
-  };
+
+
 
   const handleContinue = async () => {
-    const emailErr = validateEmail(email);
-    setEmailErrorMsg(emailErr);
-    setShowEmailError(!!emailErr);
+    const emailExists = await checkEmailExists(email);
+    
+    setLoading(true);
 
-    if (emailErr) {
-      setTimeout(() => {
+    if(emailExists?.data){
+      try {
+
+        const res = await forgotPassword(email);
+        if(res.code === 200 && res.success === 1){
+          toast.success("OTP resent successfully! Check your email.", {id: "resend-otp",});
+          navigate("/otp-verify", { state: { email } });
+        }
+
+      } catch (error) {
+        console.error("Error during password forgot:", error);
+      } finally {
         setLoading(false);
-        setError("");
-      }, 2000);
-    } else {
-      console.log("Email:", email);
+      }
+    }else{
+      toast.error("Email not in our system! Please register first")
+      navigate("/register",{ state: { email } });
+
     }
 
-    try {
-      const data = await forgotPassword(email);
-      console.log("Data to be sent:", data);
 
-      navigate("/check-password-otp", { state: { email } });
-    } catch (error) {
-      console.error("Error during password forgot:", error);
-      setError("An error occurred. Please try again.");
-    } finally {
-      setLoading(false);
-    }
   };
 
   return (
@@ -77,13 +70,9 @@ function ForgotPasswordPage() {
               value={email}
               onChange={(value) => setEmail(value)}
               showEditButton={false}
+              error= {emailError}
               className="relative w-full text-white font-sans text-sm font-semibold leading-8"
             />
-            {showEmailError && (
-              <p className="text-red-500 text-xs absolute bottom-[15px]">
-                {emailErrorMsg}
-              </p>
-            )}
           </div>
 
           {/* Continue Button */}

--- a/src/app/features/auth/pages/OtpPage.jsx
+++ b/src/app/features/auth/pages/OtpPage.jsx
@@ -1,26 +1,46 @@
 import Background from '@/components/ui/Background';
 import FormBackground from '@/components/ui/FormBackground';
 import OtpForm from '@/features/auth/components/OtpForm';
+import { signupWithEmail } from '@/services/authService';
 import toast from 'react-hot-toast';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 function OtpPage() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   
-  // Get email from URL parameters
-  const email = searchParams.get('email') || 'user@example.com';
+    const location = useLocation();
+    const email = location.state?.email;
+    const password = location.state?.password;
 
-  const handleVerifySuccess = () => {
-    toast.success('🎉 OTP Verified Successfully! Welcome!');
-    // Navigate to dashboard or next step
-    navigate('/setup-profile');
+    const handleVerifySuccess = async() => {
+      toast.success('OTP Verified Successfully!');
+      
+      if (password) {
+        toast.dismiss();
+        // Signup flow → redirect to login
+        toast.loading("Creating your account...", { id: "signup" });
+        const signupResponse = await signupWithEmail(email, password);
+
+        if (signupResponse.code === 200 && signupResponse.success === 1) {
+          toast.dismiss();
+          toast.success("Signup successful! Redirecting...", { id: "signup" });
+          navigate("/login");
+        } else {
+          toast.error(signupResponse.message || "Signup failed.", { id: "signup" });
+        }
+
+      } else {
+        // Forgot password flow → redirect to reset password
+        navigate('/reset-password', { state: { email } });
+      }
+  
   };
 
-  const handleBackToSignup = () => {
-    toast.error('Too many failed attempts. Please try signing up again.');
-    navigate('/register');
-  };
+
+    const handleMaxAttempts = () => {
+      toast.error('Too many failed attempts. Please try signing up again.');
+      navigate('/register');
+    };
 
   return (
     <Background className="min-h-screen flex items-center justify-center p-4">
@@ -28,7 +48,7 @@ function OtpPage() {
         <OtpForm
           email={email}
           onVerifySuccess={handleVerifySuccess}
-          onBackToSignup={handleBackToSignup}
+          onMaxAttemptsExceeded={handleMaxAttempts}
         />
       </FormBackground>
     </Background>

--- a/src/app/features/auth/pages/ResetPasswordPage.jsx
+++ b/src/app/features/auth/pages/ResetPasswordPage.jsx
@@ -1,114 +1,13 @@
-import React, { useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import toast from "react-hot-toast";
-import PasswordField from "@/components/ui/PasswordField";
+import React from "react";
 import Background from "@/components/ui/Background";
+import ResetPasswordForm from "../components/ResetPasswordForm";
 import FormBackground from "@/components/ui/FormBackground";
-import Button from "@/components/ui/Button";
-import { resetPassword } from "@/services/authService";
 
 function ResetPasswordPage() {
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [errors, setErrors] = useState({});
-  const [loading, setLoading] = useState(false);
-
-  const navigate = useNavigate();
-  const location = useLocation();
-  const email = location.state?.email;
-
-  // Strong password validation (8+ chars, uppercase, lowercase, number, special char)
-  const isStrongPassword = (password) =>
-    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/.test(password);
-
-  const handleUpdatePassword = async () => {
-    const newErrors = {};
-    if (!newPassword) {
-      newErrors.newPassword = "New password is required.";
-    } else if (!isStrongPassword(newPassword)) {
-      newErrors.newPassword = "Password must be at least 8 characters, include upper/lowercase, number, and symbol.";
-    }
-
-    if (!confirmPassword) {
-      newErrors.confirmPassword = "Please confirm your new password.";
-    } else if (newPassword !== confirmPassword) {
-      newErrors.confirmPassword = "Passwords do not match.";
-    }
-
-    setErrors(newErrors);
-
-    if (Object.keys(newErrors).length > 0) return;
-
-    if (!email) {
-      toast.error("Session expired or email not found. Please start over.");
-      navigate("/forgot-password");
-      return;
-    }
-
-    setLoading(true);
-    toast.loading("Updating your password...", { id: "reset-password" });
-    try {
-      await resetPassword(email, newPassword);
-      toast.success("Password updated successfully! Please log in.", { id: "reset-password" });
-      navigate("/login");
-    } catch (error) {
-      toast.error(error.message || "Failed to reset password. Please try again.", { id: "reset-password" });
-    } finally {
-      setLoading(false);
-    }
-  };
   return (
     <Background className="h-screen flex items-center justify-center">
-      <FormBackground className="flex items-center justify-around flex-col">
-        {/* Heading */}
-        <div className="text-white text-center">
-          <h1 className="font-sans font-bold text-2xl leading-8 mb-2">
-            Reset Password
-          </h1>
-          <p className="text-gray-400 text-sm">
-            Enter a new password for <span className="font-semibold text-white">{email}</span>
-          </p>
-        </div>
-
-        {/* Form Fields */}
-        <div className="w-[404px] h-[260px] flex flex-col justify-around">
-          {/* Password */}
-          <div className="-mb-8">
-            <PasswordField
-              label="Password"
-              id="password"
-              name="password"
-              placeholder="Enter your new password"
-              value={newPassword}
-              onChange={setNewPassword}
-              error={errors.newPassword}
-            />
-          </div>
-
-          <div className="-mb-8">
-            <PasswordField
-              label="Confirm New Password"
-              id="confirmNewPassword"
-              name="confirmNewPassword"
-              placeholder="Confirm your new password"
-              value={confirmPassword}
-              onChange={setConfirmPassword}
-              error={errors.confirmPassword}
-            />
-          </div>
-
-          <div className="w-full">
-            <Button
-              onClick={handleUpdatePassword}
-              variant="primary"
-              size="primary"
-              disabled={loading}
-              className="w-full transition-all duration-300 hover:-translate-y-1 hover:shadow-xl mt-3"
-            >
-              {loading ? "Updating..." : "Update Password"}
-            </Button>
-          </div>
-        </div>
+      <FormBackground className='h-auto shadow shadow-[#fff]/20'>
+        <ResetPasswordForm></ResetPasswordForm>
       </FormBackground>
     </Background>
   )

--- a/src/app/routes/authRouter.jsx
+++ b/src/app/routes/authRouter.jsx
@@ -1,5 +1,5 @@
 
-import { AuthPage, OtpPage, LoginPage, ResetPasswordPage, ForgotPasswordPage, RegisterPage, CheckPasswordOtpPage } from "@/constants/lazyload";
+import { AuthPage, OtpPage, LoginPage, ResetPasswordPage, ForgotPasswordPage, RegisterPage } from "@/constants/lazyload";
 
 
 const authRouter = [
@@ -26,10 +26,6 @@ const authRouter = [
   {
     path: "otp-verify",
     element: <OtpPage />,
-  },
-  {
-    path: "check-password-otp",
-    element: <CheckPasswordOtpPage />,
   },
   {
     path: "forgot-password",

--- a/src/app/services/authService.js
+++ b/src/app/services/authService.js
@@ -46,11 +46,23 @@ export const loginWithEmailPassword = async (email, password) => {
       email,
       password,
     });
-    const { token, user } = response.data;
+    
+    const data = response.data?.data;
 
-    // save token and user in localStorage
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify(response.data.user));
+    if (!data?.token) throw new Error("Invalid response: no token found");
+
+    // store token & user data
+    localStorage.setItem("token", data.token);
+
+    const userInfo = {
+      id: data.userId,
+      username: data.username,
+      email: data.email,
+      role: data.role,
+      roleId: data.roleId,
+      isNewUserLogin: data.isNewUserLogin,
+    };
+    localStorage.setItem("user", JSON.stringify(userInfo));
 
     return response.data;
   } catch (error) {
@@ -86,31 +98,24 @@ export const verifyOtpCode = async (email, otpCode) => {
   }
 };
 
-export const signupWithEmail = async (email, password, token = null) => {
+export const signupWithEmail = async (email, password) => {
   try {
     const response = await apiClient.post(API_ENDPOINTS.REGISTER, {
       email,
       password,
-    },
-    {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    }
-  );
-  const { token: authToken, user } = response.data;
-  // Save to localStorage
-  localStorage.setItem("token", token);
-  localStorage.setItem("user", JSON.stringify(response.data.user));
-
+    });
 
     return response.data;
   } catch (error) {
-    console.error("Error signup :", error);
+    console.error("Error signup:", error);
 
     throw error.response?.data || {
       message: "Network or server error. Please try again.",
     };
   }
 };
+
+
 
 export const forgotPassword = async (email) => {
   try {


### PR DESCRIPTION
In This PR:

- Fix send OTP API being called twice
- Update registration flow: after successful registration, route to the login page to obtain a token
- Update register OTP and forgot password OTP verification flow
- Update reset password UI and refactor related code
- Update form wrapper button text to be reusable
- Update login flow to correctly store token in localStorage
- Remove CheckPasswordOtpPage which was previously used for forgot password flow
- Remove /check-password-otp route