### PR TITLE
fix: include status in update request body in profolio admin edit form

### DIFF
--- a/src/app/features/portfolio-management/constants/data.ts
+++ b/src/app/features/portfolio-management/constants/data.ts
@@ -11,7 +11,7 @@ export interface Member {
   id: string | number;
   name: string;
   email?: string;
-  avatarUrl?: string;
+  avatarUrl?: string | null;
   role?: 'Team Leader' | 'Member';
 }
 

--- a/src/app/features/portfolio-management/hooks/use-portfolio-form.ts
+++ b/src/app/features/portfolio-management/hooks/use-portfolio-form.ts
@@ -10,6 +10,7 @@ import type { PortfolioFormMode } from '../components/portfolio-form';
 import {
   statusOptions,
   type ProjectData,
+  type ProjectStatus,
   type TeamData,
 } from '../constants/data';
 import {
@@ -17,6 +18,7 @@ import {
   type PortfolioFormValues,
 } from '../portfolio-schema';
 import { type CreateProjectPortfolioRequest } from '../services/portfolio-management-service';
+import { mapFrontendToBackendStatus } from '../utils/status-mapping';
 import {
   useAddLanguageAndTools,
   useAddTeamMember,
@@ -223,6 +225,11 @@ export const usePortfolioForm = ({
           }
           if (data.repoLink !== initialData.repoLink) {
             updatePayload.repoLink = data.repoLink;
+          }
+          if (data.status?.name && data.status.name !== initialData.status) {
+            updatePayload.projectPortfolioStatus = mapFrontendToBackendStatus(
+              data.status.name as ProjectStatus,
+            );
           }
 
           if (Object.keys(updatePayload).length > 0) {

--- a/src/app/features/portfolio-management/portfolio-schema.ts
+++ b/src/app/features/portfolio-management/portfolio-schema.ts
@@ -15,7 +15,7 @@ const memberSchema = z.object({
   id: z.union([z.string(), z.number()]),
   name: z.string(),
   email: z.string().optional(),
-  avatarUrl: z.string().optional(),
+  avatarUrl: z.string().nullable().optional(),
   role: z.enum(['Team Leader', 'Member']).optional(),
 });
 

--- a/src/app/features/portfolio-management/services/portfolio-management-service.ts
+++ b/src/app/features/portfolio-management/services/portfolio-management-service.ts
@@ -85,6 +85,7 @@ export interface CreateProjectPortfolioRequest {
     name: string;
     type: string;
   }[];
+  projectPortfolioStatus?: string;
 }
 
 export const createProjectPortfolio = async (

--- a/src/types/portfolio-management.ts
+++ b/src/types/portfolio-management.ts
@@ -22,7 +22,7 @@ export interface Member {
   name: string;
   email?: string;
   profilePictureUrl?: string;
-  avatarUrl?: string; // Added avatarUrl for compatibility with ProjectCard
+  avatarUrl?: string | null; // Added avatarUrl for compatibility with ProjectCard
   role?: 'Team Leader' | 'Member';
 }
 


### PR DESCRIPTION
Problem: Status changes from the edit form dropdown were not sent to the backend because projectPortfolioStatus was missing from the update payload.